### PR TITLE
Pixi libblas pinning issue

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -480,15 +480,15 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyerfa-2.0.1.5-py310h32771cd_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.19.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygmt-0.18.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pymc-5.27.0-h697028f_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pymc-base-5.27.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pymc-5.27.1-hafc60a3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pymc-base-5.27.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.3.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyproj-3.7.2-py313h77f6078_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyshp-3.0.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyside6-6.10.1-py313h85046ba_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pytensor-2.36.3-py313hca4dc2d_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pytensor-base-2.36.3-np2py313h73dcb5b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pytensor-2.37.0-py313h9213aec_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pytensor-base-2.37.0-np2py313h73dcb5b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-arraydiff-0.6.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.13.11-hc97d973_100_cp313.conda
@@ -1035,16 +1035,16 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pyerfa-2.0.1.5-py310hcbffc5d_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.19.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygmt-0.18.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pymc-5.27.0-h697028f_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pymc-base-5.27.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pymc-5.27.1-hafc60a3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pymc-base-5.27.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-core-12.1-py313h07bcf3a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-framework-cocoa-12.1-py313hf669bc3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.3.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pyproj-3.7.2-py313hc0f1baa_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyshp-3.0.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/pytensor-2.36.3-py313h70b93bd_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/pytensor-base-2.36.3-np2py313h1160f3e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pytensor-2.37.0-py313hf27147f_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pytensor-base-2.37.0-np2py313h1160f3e_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-arraydiff-0.6.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/python-3.13.11-h17c18a5_100_cp313.conda
@@ -1145,7 +1145,6 @@ environments:
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/_openmp_mutex-4.5-7_kmp_llvm.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/accelerate-1.12.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/adwaita-icon-theme-49.0-unix_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/aiohappyeyeballs-2.6.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aiohttp-3.13.3-py313h53c0e3e_0.conda
@@ -1187,8 +1186,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/babel-2.17.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/backports.zstd-1.3.0-py313h48bb75e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/beautifulsoup4-4.14.3-pyha770c72_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/blas-2.139-newaccelerate.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/blas-devel-3.9.0-39_he8d73f0_newaccelerate.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/blas-2.305-accelerate.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/blas-devel-3.11.0-5_h55bc449_accelerate.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/bleach-6.3.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/bleach-with-css-6.3.0-h5f6438b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/blosc-1.21.6-h7dd00d9_1.conda
@@ -1280,7 +1279,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/freexl-2.0.0-h3ab3353_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/fribidi-1.0.16-hc919400_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/frozenlist-1.7.0-py313hf28abc0_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2026.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gdk-pixbuf-2.44.4-h7542897_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/geos-3.14.1-h5afe852_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gflags-2.2.2-hf9b8971_1005.conda
@@ -1295,7 +1293,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/glpk-5.0-h6d7a090_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/glslang-16.1.0-h60b4770_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gmp-6.3.0-h7bae524_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gmpy2-2.2.1-py313hc1c22ca_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gmsh-4.15.0-h3efdf7a_4.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gmt-6.6.0-h4020263_5.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/google-crc32c-1.8.0-py313h11ab6f4_1.conda
@@ -1315,12 +1312,10 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/hatchling-1.28.0-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/hdf4-4.2.15-h2ee6834_7.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/hdf5-1.14.6-nompi_h51e7c0a_105.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/hf-xet-1.2.1-py310h6ce4931_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/hicolor-icon-theme-0.17-hce30654_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/httpcore-1.0.9-pyh29332c3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/httpx-0.28.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/huggingface_hub-1.3.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/icu-78.2-h38cb7af_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/identify-2.6.16-pyhd8ed1ab_0.conda
@@ -1376,7 +1371,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-dataset-22.0.0-hc317990_6_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-substrait-22.0.0-h144af7f_6_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libass-0.17.4-hcbd7ca7_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libblas-3.9.0-39_h4350f0c_newaccelerate.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libblas-3.11.0-5_h8d724d3_accelerate.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libboost-1.88.0-h0419b56_7.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libboost-devel-1.88.0-hf450f58_7.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libboost-headers-1.88.0-hce30654_7.conda
@@ -1385,7 +1380,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlienc-1.2.0-hc919400_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbtf-2.3.2-h99b4a89_7100102.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcamd-3.3.3-h99b4a89_7100102.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcblas-3.9.0-39_h1462f9a_newaccelerate.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcblas-3.11.0-5_h752f6bc_accelerate.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libccolamd-3.3.4-h99b4a89_7100102.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcholmod-5.3.1-hbba04d7_7100102.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libclang-cpp19.1-19.1.7-default_hf3020a7_7.conda
@@ -1424,8 +1419,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libjxl-0.11.1-h913acd8_8.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libklu-2.3.5-h4370aa4_7100102.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libkml-1.3.0-hc33e383_1022.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblapack-3.9.0-39_h7596bb1_newaccelerate.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblapacke-3.9.0-39_hfc133ca_newaccelerate.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblapack-3.11.0-5_hcb0d94e_accelerate.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblapacke-3.11.0-5_hbdd07e9_accelerate.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libldl-3.3.2-h99b4a89_7100102.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libllvm19-19.1.7-h8e0c9ce_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libllvm20-20.1.8-h8e0c9ce_1.conda
@@ -1474,11 +1469,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libtheora-1.1.1-h99b78c6_1006.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libthrift-0.22.0-h14a376c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libtiff-4.7.1-h4030677_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libtorch-2.9.1-cpu_generic_h812a54d_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libumfpack-6.3.5-h7c2c975_7100102.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libusb-1.0.29-hbc156a2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libutf8proc-2.11.3-h2431656_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libuv-1.51.0-h6caf38d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libvorbis-1.3.7-h81086ad_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libvpx-1.15.2-ha759d40_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libvulkan-loader-1.4.328.1-h49c215f_0.conda
@@ -1499,7 +1492,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lxml-6.0.2-py313he6cafaa_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lz4-c-1.10.0-h286801f_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lzo-2.10-h925e9cb_1002.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/macosx_deployment_target_osx-arm64-11.0-h214bdd9_6.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mako-1.3.10-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-4.0.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/markupsafe-3.0.3-py313h7d74516_0.conda
@@ -1515,7 +1507,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/mistune-3.2.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/mpc-1.3.1-h8f1351a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/mpfr-4.2.1-hb693164_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/mpmath-1.3.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/msgpack-python-1.1.2-py313ha61f8ec_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/multidict-6.7.0-py313h92dd972_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/multipledispatch-0.6.0-pyhd8ed1ab_1.conda
@@ -1527,10 +1518,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.5-h5e97a16_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio-1.6.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/netcdf4-1.7.4-nompi_py313hdfdf71f_102.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/networkx-3.6.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/nlohmann_json-3.12.0-h784d473_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/nodeenv-1.10.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/nomkl-1.0-h5ca1d4c_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-shim-0.2.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/numba-0.63.1-py313ha873477_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/numcodecs-0.16.5-py313h7d16b84_0.conda
@@ -1545,7 +1534,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openldap-2.6.10-hbe55e7a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.6.0-h5503f6c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/opt_einsum-3.4.0-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/optree-0.18.0-py313ha61f8ec_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/orc-2.2.1-h4fd0076_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/osqp-1.0.5-np2py313h9ce8dcc_4.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/overrides-7.7.0-pyhd8ed1ab_1.conda
@@ -1580,25 +1568,22 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.3-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyarrow-22.0.0-py313h39782a4_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyarrow-core-22.0.0-py313hcc89289_1_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-3.0.1-pyh7a1b43c_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-abi-11-hc364b38_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-global-3.0.1-pyhc7ab6ef_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.12.5-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pydantic-core-2.41.5-py313h2c089d5_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyerfa-2.0.1.5-py310hbb12772_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.19.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygmt-0.18.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pymc-5.25.1-hd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pymc-base-5.25.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pymc-5.27.1-hafc60a3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pymc-base-5.27.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyobjc-core-12.1-py313h40b429f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyobjc-framework-cocoa-12.1-py313hcc5defa_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.3.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyproj-3.7.2-py313h698103d_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyshp-3.0.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pytensor-2.31.7-py313h13cdef6_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pytensor-base-2.31.7-np2py313h08a1e76_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pytensor-2.37.0-py313h3544477_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pytensor-base-2.37.0-np2py313hdc65ad0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-arraydiff-0.6.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.13.11-hfc2f54d_100_cp313.conda
@@ -1610,7 +1595,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-json-logger-2.0.7-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2025.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-8_cp313.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pytorch-2.9.1-cpu_generic_py313_hf9b77c4_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2025.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyyaml-6.0.3-py313h7d74516_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyzmq-27.1.0-py312hd65ceae_0.conda
@@ -1628,7 +1612,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-14.2.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/rpds-py-0.30.0-py313h2c089d5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ruff-0.14.13-hb0cad00_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/safetensors-0.7.0-py313h0b74987_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/scikit-learn-1.8.0-np2py313h3b23316_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/scipy-1.17.0-py313hc753a45_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/scs-3.2.11-default_py313hf5eb8c9_0.conda
@@ -1642,10 +1625,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-scm-9.2.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/shaderc-2025.5-h1a5098f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/shapely-2.1.2-py313h10b2fc2_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/shellingham-1.5.4-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/sigtool-codesign-0.1.3-h98dc951_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/sleef-3.9.0-hb028509_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/snappy-1.2.2-hada39a4_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.8.3-pyhd8ed1ab_0.conda
@@ -1656,7 +1637,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/statsmodels-0.14.6-py313hc577518_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/suitesparse-7.10.1-h3071b36_7100102.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/svt-av1-3.1.2-h12ba402_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/sympy-1.14.0-pyh2585a3b_105.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tapi-1600.0.11.8-h997e182_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tbb-2022.3.0-h4ddebb9_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tbb-devel-2022.3.0-h213eb51_2.conda
@@ -1671,7 +1651,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.3-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/trove-classifiers-2026.1.14.14-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/typer-slim-0.21.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.15.0-h396c80c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing-inspection-0.4.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
@@ -2093,15 +2072,15 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/pyerfa-2.0.1.5-py310h1f63838_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.19.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygmt-0.18.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pymc-5.27.0-h697028f_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pymc-base-5.27.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pymc-5.27.1-hafc60a3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pymc-base-5.27.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.3.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pyproj-3.7.2-py313h24787ba_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyshp-3.0.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pyside6-6.10.1-py313h475ba69_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyh09c184e_7.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/pytensor-2.36.3-py313h2436db8_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/pytensor-base-2.36.3-np2py313h776c0ec_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pytensor-2.37.0-py313h5f2f242_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pytensor-base-2.37.0-np2py313h776c0ec_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-arraydiff-0.6.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/python-3.13.11-h09917c8_100_cp313.conda
@@ -2288,25 +2267,6 @@ packages:
   version: 2.3.1
   sha256: eeecf07f0c2a93ace0772c92e596ace6d3d3996c042b2128459aaae2a76de11d
   requires_python: '>=3.8'
-- conda: https://conda.anaconda.org/conda-forge/noarch/accelerate-1.12.0-pyhcf101f3_0.conda
-  sha256: 7351587f4771eb96b5858902d34efb4c67c1e579e745d955bc7052e204b029a6
-  md5: e02f90d5f2ee4dd409884c49839bf64c
-  depends:
-  - python >=3.10
-  - numpy >=1.17
-  - packaging >=20.0
-  - psutil
-  - pyyaml
-  - pytorch >=2.0.0
-  - huggingface_hub >=0.21.0
-  - safetensors >=0.4.3
-  - python
-  license: Apache-2.0
-  license_family: APACHE
-  purls:
-  - pkg:pypi/accelerate?source=hash-mapping
-  size: 272809
-  timestamp: 1763737594988
 - conda: https://conda.anaconda.org/conda-forge/noarch/adwaita-icon-theme-49.0-unix_0.conda
   sha256: a362b4f5c96a0bf4def96be1a77317e2730af38915eb9bec85e2a92836501ed7
   md5: b3f0179590f3c0637b7eb5309898f79e
@@ -4015,17 +3975,17 @@ packages:
   purls: []
   size: 14807
   timestamp: 1700568891544
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/blas-2.139-newaccelerate.conda
-  build_number: 39
-  sha256: 314bff5aa819fcdff41c0b9aa5310b56891da732aeb0434bc9e05b7cebca4912
-  md5: d27e537ab7980686231e21308b5581b1
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/blas-2.305-accelerate.conda
+  build_number: 5
+  sha256: 38ebdbf2fc0804e8b274977784ee1af84364d04e2d0b54630d8c11c9a0469391
+  md5: 5f941c90faaca70599ef8302d0c2738f
   depends:
-  - blas-devel 3.9.0 39*_newaccelerate
+  - blas-devel 3.11.0 5*_accelerate
   license: BSD-3-Clause
   license_family: BSD
   purls: []
-  size: 17854
-  timestamp: 1763190061041
+  size: 18815
+  timestamp: 1765819367708
 - conda: https://conda.anaconda.org/conda-forge/win-64/blas-2.305-mkl.conda
   build_number: 5
   sha256: 7ca12af1295ff4f0213bdf7ca4d08ac90d6712508f58ef132cbff8d1d8220b3f
@@ -4069,20 +4029,20 @@ packages:
   purls: []
   size: 14457
   timestamp: 1700568724421
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/blas-devel-3.9.0-39_he8d73f0_newaccelerate.conda
-  build_number: 39
-  sha256: b813a5c76a7ed60ae507b0420a73ac2c0c8640a1762d8a625bdc8e726e4e30d3
-  md5: 7c823d9abfbb92310aa018a2e7b01c2a
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/blas-devel-3.11.0-5_h55bc449_accelerate.conda
+  build_number: 5
+  sha256: 37077b57f8f6b2543ec69e48795e2a45275047aba83842922db55a122081c995
+  md5: 6696b095e91860523bcc97303e11d30d
   depends:
-  - libblas 3.9.0 39_h4350f0c_newaccelerate
-  - libcblas 3.9.0 39_h1462f9a_newaccelerate
-  - liblapack 3.9.0 39_h7596bb1_newaccelerate
-  - liblapacke 3.9.0 39_hfc133ca_newaccelerate
+  - libblas 3.11.0 5_h8d724d3_accelerate
+  - libcblas 3.11.0 5_h752f6bc_accelerate
+  - liblapack 3.11.0 5_hcb0d94e_accelerate
+  - liblapacke 3.11.0 5_hbdd07e9_accelerate
   license: BSD-3-Clause
   license_family: BSD
   purls: []
-  size: 17411
-  timestamp: 1763190032120
+  size: 18156
+  timestamp: 1765819324113
 - conda: https://conda.anaconda.org/conda-forge/win-64/blas-devel-3.11.0-5_h85df5b5_mkl.conda
   build_number: 5
   sha256: 82abd32342b85c12f03d24f495bf8dcc3b04fab151db2b579ec25314f4b59a92
@@ -4806,7 +4766,7 @@ packages:
   timestamp: 1768852915341
 - pypi: ./
   name: celeri
-  version: 0.0.post1.dev1+g5d10869ee
+  version: 0.0.post1.dev2159+g62618b1ba.d20260127
   sha256: 8b5e5dd94560093912ffdf179b670db7716c1707833690d8732b5e61ca298332
   requires_dist:
   - cartopy
@@ -7519,17 +7479,6 @@ packages:
   - pkg:pypi/frozenlist?source=hash-mapping
   size: 49129
   timestamp: 1752167418796
-- conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2026.1.0-pyhd8ed1ab_0.conda
-  sha256: bfba6c280366f48b00a6a7036988fc2bc3fea5ac1d8303152c9da69d72a22936
-  md5: 1daaf94a304a27ba3446a306235a37ea
-  depends:
-  - python >=3.10
-  license: BSD-3-Clause
-  license_family: BSD
-  purls:
-  - pkg:pypi/fsspec?source=compressed-mapping
-  size: 148116
-  timestamp: 1768000866082
 - pypi: https://files.pythonhosted.org/packages/1d/33/f1c6a276de27b7d7339a34749cc33fa87f077f921969c47185d34a887ae2/gast-0.7.0-py3-none-any.whl
   name: gast
   version: 0.7.0
@@ -8214,23 +8163,6 @@ packages:
   purls: []
   size: 365188
   timestamp: 1718981343258
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/gmpy2-2.2.1-py313hc1c22ca_2.conda
-  sha256: 6d04a256743e19e951c2fd6de8741c259fa4c13ffd067669633e850f5211a97f
-  md5: 08bbc47d90ccee895465f61b8692e236
-  depends:
-  - __osx >=11.0
-  - gmp >=6.3.0,<7.0a0
-  - mpc >=1.3.1,<2.0a0
-  - mpfr >=4.2.1,<5.0a0
-  - python >=3.13,<3.14.0a0
-  - python >=3.13,<3.14.0a0 *_cp313
-  - python_abi 3.13.* *_cp313
-  license: LGPL-3.0-or-later
-  license_family: LGPL
-  purls:
-  - pkg:pypi/gmpy2?source=hash-mapping
-  size: 162903
-  timestamp: 1762947509599
 - conda: https://conda.anaconda.org/conda-forge/linux-64/gmsh-4.15.0-hbdcdd55_4.conda
   sha256: fcdd9bcc8eb9160ae4cd0336405bb20a77365b16aa1751611ccf4d8341cb72a7
   md5: 2e53d20e008d26d2a85f46c5d149e8a5
@@ -9253,24 +9185,6 @@ packages:
   purls: []
   size: 2028299
   timestamp: 1768857717770
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/hf-xet-1.2.1-py310h6ce4931_0.conda
-  noarch: python
-  sha256: e101714629795f382b3da88473fff0d1c41010b0c827781b1365960768d14d37
-  md5: 25c8979ef595b889ec105be9964738f4
-  depends:
-  - python
-  - __osx >=11.0
-  - openssl >=3.5.4,<4.0a0
-  - _python_abi3_support 1.*
-  - cpython >=3.10
-  constrains:
-  - __osx >=11.0
-  license: Apache-2.0
-  license_family: APACHE
-  purls:
-  - pkg:pypi/hf-xet?source=hash-mapping
-  size: 2517013
-  timestamp: 1763772770292
 - conda: https://conda.anaconda.org/conda-forge/linux-64/hicolor-icon-theme-0.17-ha770c72_2.tar.bz2
   sha256: 336f29ceea9594f15cc8ec4c45fdc29e10796573c697ee0d57ebb7edd7e92043
   md5: bbf6f174dcd3254e19a2f5d2295ce808
@@ -9338,29 +9252,6 @@ packages:
   - pkg:pypi/httpx?source=hash-mapping
   size: 63082
   timestamp: 1733663449209
-- conda: https://conda.anaconda.org/conda-forge/noarch/huggingface_hub-1.3.2-pyhd8ed1ab_0.conda
-  sha256: f1db664fbbf059c37727b044fd52a3bc8527009f72e27b7518fff62c2e589120
-  md5: b722bcb95cd7ffc786342ad51bfcb8ce
-  depends:
-  - filelock
-  - fsspec >=2023.5.0
-  - hf-xet >=1.2.0,<2.0.0
-  - httpx >=0.23.0,<1
-  - packaging >=20.9
-  - python >=3.10
-  - pyyaml >=5.1
-  - requests
-  - shellingham
-  - tqdm >=4.42.1
-  - typer-slim
-  - typing-extensions >=3.7.4.3
-  - typing_extensions >=4.1.0
-  license: Apache-2.0
-  license_family: APACHE
-  purls:
-  - pkg:pypi/huggingface-hub?source=hash-mapping
-  size: 331393
-  timestamp: 1768507495934
 - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
   sha256: 77af6f5fe8b62ca07d09ac60127a30d9069fdc3c68d6b256754d0ffb1f7779f8
   md5: 8e6923fc12f1fe8f8c4e5c9f343256ac
@@ -11391,29 +11282,28 @@ packages:
   purls: []
   size: 15075
   timestamp: 1700568635315
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libblas-3.9.0-39_h4350f0c_newaccelerate.conda
-  build_number: 39
-  sha256: 3e15ebc732a9b33d66cf9788963c95f56cd43ae3b926402cd9bad5cb263fa8bc
-  md5: 7418a28b88fda3b2cdf729f2ca63b7cc
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libblas-3.11.0-5_h8d724d3_accelerate.conda
+  build_number: 5
+  sha256: cf669611f2f69c2a9af97501d3692b8ed6175c318426cc8dc9560f22a79972a9
+  md5: c32b3b0d73d5cb1ab2a095a69bf3a7bd
   depends:
   - __osx >=11.0
-  - __osx >=13.3
   - libgfortran
   - libgfortran5 >=14.3.0
   constrains:
+  - blas 2.305   accelerate
+  - liblapack  3.11.0   5*_accelerate
+  - libcblas   3.11.0   5*_accelerate
+  - liblapacke 3.11.0   5*_accelerate
   - mkl <2026
-  - liblapacke 3.9.0   39*_newaccelerate
-  - libcblas   3.9.0   39*_newaccelerate
-  - liblapack  3.9.0   39*_newaccelerate
-  - blas 2.139   newaccelerate
   track_features:
-  - blas_newaccelerate
-  - blas_newaccelerate_2
+  - blas_accelerate
+  - blas_accelerate_2
   license: BSD-3-Clause
   license_family: BSD
   purls: []
-  size: 382243
-  timestamp: 1763189998230
+  size: 2832661
+  timestamp: 1765819275660
 - conda: https://conda.anaconda.org/conda-forge/win-64/libblas-3.11.0-5_hf2e6a31_mkl.conda
   build_number: 5
   sha256: f0cb7b2697461a306341f7ff32d5b361bb84f3e94478464c1e27ee01fc8f276b
@@ -11795,23 +11685,23 @@ packages:
   purls: []
   size: 14694
   timestamp: 1700568672081
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcblas-3.9.0-39_h1462f9a_newaccelerate.conda
-  build_number: 39
-  sha256: 76d491d57448dca4c8ee3036650d6d7af512ed57db1dac9552d55202fd86367f
-  md5: c260a7261442a76d7eef60c36cc08a98
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcblas-3.11.0-5_h752f6bc_accelerate.conda
+  build_number: 5
+  sha256: b81bbaceeec11de119aa8a396b40c7d78c4a5884f9455e8095c8e412318e1916
+  md5: e5733907c1c77e6db5012c299e42a5ad
   depends:
-  - libblas 3.9.0 39_h4350f0c_newaccelerate
+  - libblas 3.11.0 5_h8d724d3_accelerate
   constrains:
-  - liblapack  3.9.0   39*_newaccelerate
-  - blas 2.139   newaccelerate
-  - liblapacke 3.9.0   39*_newaccelerate
+  - blas 2.305   accelerate
+  - liblapack  3.11.0   5*_accelerate
+  - liblapacke 3.11.0   5*_accelerate
   track_features:
-  - blas_newaccelerate
+  - blas_accelerate
   license: BSD-3-Clause
   license_family: BSD
   purls: []
-  size: 17742
-  timestamp: 1763190009928
+  size: 18497
+  timestamp: 1765819293662
 - conda: https://conda.anaconda.org/conda-forge/win-64/libcblas-3.11.0-5_h2a3cdd5_mkl.conda
   build_number: 5
   sha256: 49dc59d8e58360920314b8d276dd80da7866a1484a9abae4ee2760bc68f3e68d
@@ -13924,23 +13814,23 @@ packages:
   purls: []
   size: 14699
   timestamp: 1700568690313
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblapack-3.9.0-39_h7596bb1_newaccelerate.conda
-  build_number: 39
-  sha256: 573d611d048602d5a956b5e9a6a507ae1feb1b61a4b1b79231cae5e264763ba4
-  md5: 907ef1854f707e58429f3d35edc33233
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblapack-3.11.0-5_hcb0d94e_accelerate.conda
+  build_number: 5
+  sha256: 0f89238f9550fb603a39a6644801a15226a228a4b3996499fd52eff9f03eae44
+  md5: 3b5a735865842f8d6bf8b78b376ca9e1
   depends:
-  - libblas 3.9.0 39_h4350f0c_newaccelerate
+  - libblas 3.11.0 5_h8d724d3_accelerate
   constrains:
-  - blas 2.139   newaccelerate
-  - liblapacke 3.9.0   39*_newaccelerate
-  - libcblas   3.9.0   39*_newaccelerate
+  - blas 2.305   accelerate
+  - liblapacke 3.11.0   5*_accelerate
+  - libcblas   3.11.0   5*_accelerate
   track_features:
-  - blas_newaccelerate
+  - blas_accelerate
   license: BSD-3-Clause
   license_family: BSD
   purls: []
-  size: 17742
-  timestamp: 1763190019169
+  size: 18506
+  timestamp: 1765819305836
 - conda: https://conda.anaconda.org/conda-forge/win-64/liblapack-3.11.0-5_hf9ab0e9_mkl.conda
   build_number: 5
   sha256: a2d33f5cc2b8a9042f2af6981c6733ab1a661463823eaa56595a9c58c0ab77e1
@@ -13990,23 +13880,23 @@ packages:
   purls: []
   size: 14695
   timestamp: 1700568707184
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblapacke-3.9.0-39_hfc133ca_newaccelerate.conda
-  build_number: 39
-  sha256: 4f69ac1c5b53aeee8fbce445e9d0ad7b0d2789fd482a938c9f84085b49c3e935
-  md5: 36e9348405f98065ac9c265a46ddca1d
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblapacke-3.11.0-5_hbdd07e9_accelerate.conda
+  build_number: 5
+  sha256: 6513c79e8b890190b42dc63d37ac91561da6586aa64d291184ebd842e8b5f6f3
+  md5: 29c7d09cbe6d342ced64b0447e1f3792
   depends:
-  - libblas 3.9.0 39_h4350f0c_newaccelerate
-  - libcblas 3.9.0 39_h1462f9a_newaccelerate
-  - liblapack 3.9.0 39_h7596bb1_newaccelerate
+  - libblas 3.11.0 5_h8d724d3_accelerate
+  - libcblas 3.11.0 5_h752f6bc_accelerate
+  - liblapack 3.11.0 5_hcb0d94e_accelerate
   constrains:
-  - blas 2.139   newaccelerate
+  - blas 2.305   accelerate
   track_features:
-  - blas_newaccelerate
+  - blas_accelerate
   license: BSD-3-Clause
   license_family: BSD
   purls: []
-  size: 17751
-  timestamp: 1763190028661
+  size: 18530
+  timestamp: 1765819320692
 - conda: https://conda.anaconda.org/conda-forge/win-64/liblapacke-3.11.0-5_h3ae206f_mkl.conda
   build_number: 5
   sha256: 72f312334765605cc456faa1a818d2fb6697fddc6fda798eed8408c20df19ad6
@@ -16207,35 +16097,6 @@ packages:
   purls: []
   size: 993166
   timestamp: 1762022118895
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libtorch-2.9.1-cpu_generic_h812a54d_3.conda
-  sha256: 5aa177b02af2a979d293fa2212a893da8ceeafd5133669ab60fd1fe2f063d390
-  md5: 7f333017d415d7104592feeac90e5f61
-  depends:
-  - __osx >=11.0
-  - fmt >=12.1.0,<12.2.0a0
-  - libabseil * cxx17*
-  - libabseil >=20250512.1,<20250513.0a0
-  - libblas >=3.9.0,<4.0a0
-  - libcblas >=3.9.0,<4.0a0
-  - libcxx >=19
-  - liblapack >=3.9.0,<4.0a0
-  - libprotobuf >=6.31.1,<6.31.2.0a0
-  - libuv >=1.51.0,<2.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - llvm-openmp >=19.1.7
-  - pybind11-abi 11
-  - sleef >=3.9.0,<4.0a0
-  constrains:
-  - pytorch-cpu 2.9.1
-  - pytorch-gpu <0.0a0
-  - openblas * openmp_*
-  - libopenblas * openmp_*
-  - pytorch 2.9.1 cpu_generic_*_3
-  license: BSD-3-Clause
-  license_family: BSD
-  purls: []
-  size: 30560002
-  timestamp: 1768336987766
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libudev1-257.10-hd0affe5_3.conda
   sha256: 977e7e4955ea1581e441e429c2c1b498bc915767f1cac77a97b283c469d5298c
   md5: 3934f4cf65a06100d526b33395fb9cd2
@@ -16402,16 +16263,6 @@ packages:
   purls: []
   size: 40311
   timestamp: 1766271528534
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libuv-1.51.0-h6caf38d_1.conda
-  sha256: 042c7488ad97a5629ec0a991a8b2a3345599401ecc75ad6a5af73b60e6db9689
-  md5: c0d87c3c8e075daf1daf6c31b53e8083
-  depends:
-  - __osx >=11.0
-  license: MIT
-  license_family: MIT
-  purls: []
-  size: 421195
-  timestamp: 1753948426421
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libva-2.23.0-he1eb515_0.conda
   sha256: 255c7d00b54e26f19fad9340db080716bced1d8539606e2b8396c57abd40007c
   md5: 25813fe38b3e541fc40007592f12bae5
@@ -17506,13 +17357,6 @@ packages:
   purls: []
   size: 8421
   timestamp: 1759768559974
-- conda: https://conda.anaconda.org/conda-forge/noarch/macosx_deployment_target_osx-arm64-11.0-h214bdd9_6.conda
-  sha256: df86468d0e069f12c293ec9cc1490869d946b36f97d41e7fa1d94a6f8e631102
-  md5: a24c4faab7bbdb292f2de71af134c3e8
-  license: BSD-3-Clause
-  purls: []
-  size: 4959
-  timestamp: 1768922843288
 - conda: https://conda.anaconda.org/conda-forge/noarch/mako-1.3.10-pyhcf101f3_1.conda
   sha256: 6099a13faaaf22afa8daa273929f393d41140fc03509b4ef1e2f6858b511699d
   md5: 99f74609a309e434f25f0ede5f50580c
@@ -18282,17 +18126,6 @@ packages:
   purls: []
   size: 491140
   timestamp: 1730581373280
-- conda: https://conda.anaconda.org/conda-forge/noarch/mpmath-1.3.0-pyhd8ed1ab_1.conda
-  sha256: 7d7aa3fcd6f42b76bd711182f3776a02bef09a68c5f117d66b712a6d81368692
-  md5: 3585aa87c43ab15b167b574cd73b057b
-  depends:
-  - python >=3.9
-  license: BSD-3-Clause
-  license_family: BSD
-  purls:
-  - pkg:pypi/mpmath?source=hash-mapping
-  size: 439705
-  timestamp: 1733302781386
 - conda: https://conda.anaconda.org/conda-forge/linux-64/msgpack-python-1.1.2-py313h7037e92_1.conda
   sha256: fac37e267dd1d07527f0b078ffe000916e80e8c89cfe69d466f5775b88e93df2
   md5: cd1cfde0ea3bca6c805c73ffa988b12a
@@ -18670,23 +18503,6 @@ packages:
   - pkg:pypi/netcdf4?source=hash-mapping
   size: 1032230
   timestamp: 1768552899502
-- conda: https://conda.anaconda.org/conda-forge/noarch/networkx-3.6.1-pyhcf101f3_0.conda
-  sha256: f6a82172afc50e54741f6f84527ef10424326611503c64e359e25a19a8e4c1c6
-  md5: a2c1eeadae7a309daed9d62c96012a2b
-  depends:
-  - python >=3.11
-  - python
-  constrains:
-  - numpy >=1.25
-  - scipy >=1.11.2
-  - matplotlib-base >=3.8
-  - pandas >=2.0
-  license: BSD-3-Clause
-  license_family: BSD
-  purls:
-  - pkg:pypi/networkx?source=compressed-mapping
-  size: 1587439
-  timestamp: 1765215107045
 - conda: https://conda.anaconda.org/conda-forge/linux-64/nlohmann_json-3.12.0-h54a6638_1.conda
   sha256: fd2cbd8dfc006c72f45843672664a8e4b99b2f8137654eaae8c3d46dca776f63
   md5: 16c2a0e9c4a166e53632cfca4f68d020
@@ -18739,16 +18555,6 @@ packages:
   - pkg:pypi/nodeenv?source=hash-mapping
   size: 40866
   timestamp: 1766261270149
-- conda: https://conda.anaconda.org/conda-forge/noarch/nomkl-1.0-h5ca1d4c_0.tar.bz2
-  sha256: d38542a151a90417065c1a234866f97fd1ea82a81de75ecb725955ab78f88b4b
-  md5: 9a66894dfd07c4510beb6b3f9672ccc0
-  constrains:
-  - mkl <0.a0
-  license: BSD-3-Clause
-  license_family: BSD
-  purls: []
-  size: 3843
-  timestamp: 1582593857545
 - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-shim-0.2.4-pyhd8ed1ab_1.conda
   sha256: 7b920e46b9f7a2d2aa6434222e5c8d739021dbc5cc75f32d124a8191d86f9056
   md5: e7f89ea5f7ea9401642758ff50a2d9c1
@@ -19677,22 +19483,6 @@ packages:
   - pkg:pypi/opt-einsum?source=hash-mapping
   size: 62479
   timestamp: 1733688053334
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/optree-0.18.0-py313ha61f8ec_0.conda
-  sha256: cc7879d8d77c9f285dd30b150837c08fdae55fd7313f053501d2e67604f5b3c2
-  md5: 08c825d0a6cde154eb8c4729563114e7
-  depends:
-  - __osx >=11.0
-  - libcxx >=19
-  - python >=3.13,<3.14.0a0
-  - python >=3.13,<3.14.0a0 *_cp313
-  - python_abi 3.13.* *_cp313
-  - typing-extensions >=4.12
-  license: Apache-2.0
-  license_family: Apache
-  purls:
-  - pkg:pypi/optree?source=hash-mapping
-  size: 400259
-  timestamp: 1763125014948
 - conda: https://conda.anaconda.org/conda-forge/linux-64/orc-2.2.1-hd747db4_0.conda
   sha256: 8d91d6398fc63a94d238e64e4983d38f6f9555460f11bed00abb2da04dbadf7c
   md5: ddab8b2af55b88d63469c040377bd37e
@@ -21136,44 +20926,6 @@ packages:
   - pkg:pypi/pyarrow?source=hash-mapping
   size: 3538959
   timestamp: 1768962869914
-- conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-3.0.1-pyh7a1b43c_0.conda
-  sha256: 2558727093f13d4c30e124724566d16badd7de532fd8ee7483628977117d02be
-  md5: 70ece62498c769280f791e836ac53fff
-  depends:
-  - python >=3.8
-  - pybind11-global ==3.0.1 *_0
-  - python
-  constrains:
-  - pybind11-abi ==11
-  license: BSD-3-Clause
-  license_family: BSD
-  purls:
-  - pkg:pypi/pybind11?source=hash-mapping
-  size: 232875
-  timestamp: 1755953378112
-- conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-abi-11-hc364b38_1.conda
-  sha256: 9e7fe12f727acd2787fb5816b2049cef4604b7a00ad3e408c5e709c298ce8bf1
-  md5: f0599959a2447c1e544e216bddf393fa
-  license: BSD-3-Clause
-  license_family: BSD
-  purls: []
-  size: 14671
-  timestamp: 1752769938071
-- conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-global-3.0.1-pyhc7ab6ef_0.conda
-  sha256: f11a5903879fe3a24e0d28329cb2b1945127e85a4cdb444b45545cf079f99e2d
-  md5: fe10b422ce8b5af5dab3740e4084c3f9
-  depends:
-  - python >=3.8
-  - __unix
-  - python
-  constrains:
-  - pybind11-abi ==11
-  license: BSD-3-Clause
-  license_family: BSD
-  purls:
-  - pkg:pypi/pybind11-global?source=hash-mapping
-  size: 228871
-  timestamp: 1755953338243
 - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
   sha256: 79db7928d13fab2d892592223d7570f5061c192f27b9febd1a418427b719acc6
   md5: 12c566707c80111f9799308d9e265aef
@@ -21359,55 +21111,20 @@ packages:
   - pkg:pypi/pygmt?source=hash-mapping
   size: 205112
   timestamp: 1768189945712
-- conda: https://conda.anaconda.org/conda-forge/noarch/pymc-5.25.1-hd8ed1ab_0.conda
-  noarch: python
-  sha256: 04608f683743ce237eae10712dbc7b8bef5658a78cccf9c7038913618225c809
-  md5: 95fec6c924868a8585c551dba3fa1722
+- conda: https://conda.anaconda.org/conda-forge/noarch/pymc-5.27.1-hafc60a3_0.conda
+  sha256: c026474c9a0fe0b48e20b7c662b83f90983fe1052dab92790825fb9407d1f9fe
+  md5: eafe76a74117b541b731326f4b8cafd7
   depends:
-  - pymc-base 5.25.1 pyhd8ed1ab_0
+  - pymc-base ==5.27.1 pyhcf101f3_0
   - pytensor
   - python-graphviz
   license: Apache-2.0
-  license_family: Apache
   purls: []
-  size: 12157
-  timestamp: 1753370496303
-- conda: https://conda.anaconda.org/conda-forge/noarch/pymc-5.27.0-h697028f_0.conda
-  sha256: 23a8bdd3afc24de494b4862a84408717485b3c19f402b414fab7144777d3eb72
-  md5: 0723078bea2ed23ac3c4af664ba78d3e
-  depends:
-  - pymc-base ==5.27.0 pyhcf101f3_0
-  - pytensor
-  - python-graphviz
-  license: Apache-2.0
-  license_family: APACHE
-  purls: []
-  size: 9895
-  timestamp: 1766392078774
-- conda: https://conda.anaconda.org/conda-forge/noarch/pymc-base-5.25.1-pyhd8ed1ab_0.conda
-  sha256: e71c424fe08866fd36b9b2a2c8b8856f5f8ae5ca5673124a02950e31e0c90170
-  md5: f947ff1e38e9c1293e3b54d5bb7d9a8e
-  depends:
-  - arviz >=0.13.0
-  - cachetools >=4.2.1
-  - cloudpickle
-  - numpy >=1.25.0
-  - pandas >=0.24.0
-  - pytensor-base >=2.31.7,<2.32
-  - python >=3.10
-  - rich >=13.7.1
-  - scipy >=1.4.1
-  - threadpoolctl >=3.1.0,<4.0.0
-  - typing_extensions >=3.7.4
-  license: Apache-2.0
-  license_family: Apache
-  purls:
-  - pkg:pypi/pymc?source=hash-mapping
-  size: 356585
-  timestamp: 1753370492771
-- conda: https://conda.anaconda.org/conda-forge/noarch/pymc-base-5.27.0-pyhcf101f3_0.conda
-  sha256: c88eebef77b74a72f01df1aed5adb7fbd4d703509dacf16bbf9448857530c6a4
-  md5: 5f66d17898ad6073ea7df40d2e514a9d
+  size: 9894
+  timestamp: 1769443677109
+- conda: https://conda.anaconda.org/conda-forge/noarch/pymc-base-5.27.1-pyhcf101f3_0.conda
+  sha256: 935605f3b651fb032caa2e339a721d1c8979f9a13e79f59d11ca02e9d7b2a08c
+  md5: 5b63fdd6d12db7244e20f63950856bc9
   depends:
   - python >=3.11
   - arviz >=0.13.0
@@ -21415,18 +21132,17 @@ packages:
   - cloudpickle
   - numpy >=1.25.0
   - pandas >=0.24.0
-  - pytensor-base >=2.36.0,<2.37
+  - pytensor-base >=2.37.0,<2.38.0
   - rich >=13.7.1
   - scipy >=1.4.1
   - threadpoolctl >=3.1.0,<4.0.0
   - typing_extensions >=3.7.4
   - python
   license: Apache-2.0
-  license_family: APACHE
   purls:
   - pkg:pypi/pymc?source=hash-mapping
-  size: 383855
-  timestamp: 1766392078773
+  size: 391942
+  timestamp: 1769443677107
 - conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-core-12.1-py313h07bcf3a_0.conda
   sha256: 1e0edd34b804e20ba064dcebcfce3066d841ec812f29ed65902da7192af617d1
   md5: 6a2c3a617a70f97ca53b7b88461b1c27
@@ -21648,59 +21364,53 @@ packages:
   - pkg:pypi/pysocks?source=hash-mapping
   size: 21085
   timestamp: 1733217331982
-- conda: https://conda.anaconda.org/conda-forge/linux-64/pytensor-2.36.3-py313hca4dc2d_1.conda
-  sha256: 55a2611247973459eac891c56fd6e10a758addf958902857652a3cdbe7e34a9d
-  md5: 53ba891e280335d048ed4f078ad67039
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pytensor-2.37.0-py313h9213aec_1.conda
+  sha256: 1e11e7b2195b11c78cd3a65c620d099da4436acc029d970f16de7fb016a3c3ae
+  md5: 6a8538a792c8fbc06f8854555e490434
   depends:
   - python
-  - pytensor-base ==2.36.3 np2py313h73dcb5b_1
+  - pytensor-base ==2.37.0 np2py313h73dcb5b_1
   - gxx
   - blas * mkl
   - mkl-service
   - python_abi 3.13.* *_cp313
   license: BSD-3-Clause
-  license_family: BSD
   purls: []
-  size: 11672
-  timestamp: 1768253375708
-- conda: https://conda.anaconda.org/conda-forge/osx-64/pytensor-2.36.3-py313h70b93bd_1.conda
-  sha256: 6f2fbecda888cc2836ada2d7b61487fea6e12f192ba0ab20a94e979227f08620
-  md5: 67a334ee5d05307010fec8605d68638d
+  size: 11685
+  timestamp: 1769453361365
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pytensor-2.37.0-py313hf27147f_1.conda
+  sha256: d86cea178f08e851138f9be44228e889bbef74e64634231e82a1c2545ed3bd06
+  md5: 3b093cab3f8a43c38ff1315babe7f93d
   depends:
   - python
-  - pytensor-base ==2.36.3 np2py313h1160f3e_1
+  - pytensor-base ==2.37.0 np2py313h1160f3e_1
   - clangxx
   - blas * mkl
   - mkl-service
   - python_abi 3.13.* *_cp313
   license: BSD-3-Clause
-  license_family: BSD
   purls: []
-  size: 10396
-  timestamp: 1768253340849
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pytensor-2.31.7-py313h13cdef6_0.conda
-  sha256: e50356ea8de3d120b0ac31e7d65032620c3785d2de6c9657bebf6961cf39a7f2
-  md5: dd47c937ec21f570715c92988df16689
+  size: 10406
+  timestamp: 1769453428716
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pytensor-2.37.0-py313h3544477_0.conda
+  sha256: 6e189d70074da832ea8a54d7a4d6f2ae2769afe7f6a2403ba776434f7ed68599
+  md5: 325b7bd63fcfe6905e824b030e9fac96
   depends:
   - python
-  - pytensor-base ==2.31.7 np2py313h08a1e76_0
-  - clang_osx-arm64 19.*
-  - macosx_deployment_target_osx-arm64 11.0.*
-  - clangxx_osx-arm64 19.*
-  - accelerate
-  - blas
+  - pytensor-base ==2.37.0 np2py313hdc65ad0_0
+  - clangxx
+  - blas * accelerate
   - python_abi 3.13.* *_cp313
   license: BSD-3-Clause
-  license_family: BSD
   purls: []
-  size: 9709
-  timestamp: 1752049766524
-- conda: https://conda.anaconda.org/conda-forge/win-64/pytensor-2.36.3-py313h2436db8_1.conda
-  sha256: 69b443edd048c80c58d633c28eda6969cd08879029e95a33ee42b1e8c6670697
-  md5: 634ca2281a4c58ddba1754faac11cc93
+  size: 10541
+  timestamp: 1769252184992
+- conda: https://conda.anaconda.org/conda-forge/win-64/pytensor-2.37.0-py313h5f2f242_1.conda
+  sha256: de908dce5d924a654114a38483bb6a7b900de0349b11c8f0d5f4a10b0205e515
+  md5: f77184a3a76089d11aaae5d30ada7652
   depends:
   - python
-  - pytensor-base ==2.36.3 np2py313h776c0ec_1
+  - pytensor-base ==2.37.0 np2py313h776c0ec_1
   - gxx
   - blas * mkl
   - mkl-service
@@ -21708,13 +21418,12 @@ packages:
   constrains:
   - libstdcxx !=15.1.0
   license: BSD-3-Clause
-  license_family: BSD
   purls: []
-  size: 10803
-  timestamp: 1768253378781
-- conda: https://conda.anaconda.org/conda-forge/linux-64/pytensor-base-2.36.3-np2py313h73dcb5b_1.conda
-  sha256: 77be5ee9485f40bf9f5c990bc0cb856298878fa4c59945ff62db25723ec418f0
-  md5: 1f8cf7555a040ce6f684bda073ef164e
+  size: 10825
+  timestamp: 1769453402031
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pytensor-base-2.37.0-np2py313h73dcb5b_1.conda
+  sha256: c18f325419b6c20cd4a1739611bfda7fa6a55cfbf5e111be2a2456d861c58604
+  md5: c17179000db4c2bf23222d560bd71b7a
   depends:
   - python
   - setuptools >=59.0.0
@@ -21729,17 +21438,16 @@ packages:
   - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - numpy >=1.23,<3
   - python_abi 3.13.* *_cp313
+  - numpy >=1.23,<3
   license: BSD-3-Clause
-  license_family: BSD
   purls:
   - pkg:pypi/pytensor?source=hash-mapping
-  size: 2768579
-  timestamp: 1768253375706
-- conda: https://conda.anaconda.org/conda-forge/osx-64/pytensor-base-2.36.3-np2py313h1160f3e_1.conda
-  sha256: d0325dff9ec1355ca8bce26b5ab17f08330e609576ba2cff4bb0a1b2775f1263
-  md5: 987069810727cf9bb099f5b5e12f8b8a
+  size: 2788702
+  timestamp: 1769453361364
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pytensor-base-2.37.0-np2py313h1160f3e_1.conda
+  sha256: d0928b6229d272605b32e6329041ff6005ba8c6cc2506d5701013a20a32af076
+  md5: 8c94c786f3c3dbe0e2a9e428df749329
   depends:
   - python
   - setuptools >=59.0.0
@@ -21751,43 +21459,42 @@ packages:
   - logical-unification
   - minikanren
   - cons
-  - __osx >=10.13
   - libcxx >=19
+  - __osx >=10.13
   - python_abi 3.13.* *_cp313
   - numpy >=1.23,<3
   license: BSD-3-Clause
-  license_family: BSD
   purls:
   - pkg:pypi/pytensor?source=hash-mapping
-  size: 2765504
-  timestamp: 1768253340845
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pytensor-base-2.31.7-np2py313h08a1e76_0.conda
-  sha256: 1aeab81e6a1f8fa20de51f1d4b4f85e02a17323eaf7ad3698c93f4bc0db32cbd
-  md5: 2abe2d1e04d6d3f76b8d2381a0eb0614
+  size: 2784391
+  timestamp: 1769453428707
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pytensor-base-2.37.0-np2py313hdc65ad0_0.conda
+  sha256: a203b81be1ab9d6efa40bb7cdedb5beea589405db7f1e726171e8d5c8d8491c1
+  md5: 5f492c00b48db000d301ac3dae3ed416
   depends:
   - python
   - setuptools >=59.0.0
   - scipy >=1,<2
-  - numpy >=1.17.0
+  - numpy >=2.0
+  - numba >0.57,<1
   - filelock >=3.15
   - etuples
   - logical-unification
   - minikanren
   - cons
-  - python 3.13.* *_cp313
   - libcxx >=19
+  - python 3.13.* *_cp313
   - __osx >=11.0
-  - python_abi 3.13.* *_cp313
   - numpy >=1.23,<3
+  - python_abi 3.13.* *_cp313
   license: BSD-3-Clause
-  license_family: BSD
   purls:
   - pkg:pypi/pytensor?source=hash-mapping
-  size: 2728733
-  timestamp: 1752049766522
-- conda: https://conda.anaconda.org/conda-forge/win-64/pytensor-base-2.36.3-np2py313h776c0ec_1.conda
-  sha256: a09fc933d607b148f975afe27f4b5f3fd2bf3b578b5a63d5e776f8ec5f415ae5
-  md5: 3a64df2ef3d576282c05cd57e12c6a34
+  size: 2787509
+  timestamp: 1769252184985
+- conda: https://conda.anaconda.org/conda-forge/win-64/pytensor-base-2.37.0-np2py313h776c0ec_1.conda
+  sha256: 2dc55403ef8cdd29956dbda69ac2f9d7f8cf43420d3e5a1ca3699c46b7cd9a6e
+  md5: b724c7707153427aaa72dcc2347597f0
   depends:
   - python
   - setuptools >=59.0.0
@@ -21802,14 +21509,13 @@ packages:
   - vc >=14.3,<15
   - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - python_abi 3.13.* *_cp313
   - numpy >=1.23,<3
+  - python_abi 3.13.* *_cp313
   license: BSD-3-Clause
-  license_family: BSD
   purls:
   - pkg:pypi/pytensor?source=hash-mapping
-  size: 2799121
-  timestamp: 1768253378776
+  size: 2813887
+  timestamp: 1769453402026
 - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.2-pyhcf101f3_0.conda
   sha256: 9e749fb465a8bedf0184d8b8996992a38de351f7c64e967031944978de03a520
   md5: 2b694bad8a50dc2f712f5368de866480
@@ -22035,46 +21741,6 @@ packages:
   purls: []
   size: 7002
   timestamp: 1752805902938
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pytorch-2.9.1-cpu_generic_py313_hf9b77c4_3.conda
-  sha256: 43f7b3bfad555fa5e60c62bd6406eb7f6310a522491289cfac840dbe79710cf7
-  md5: 2578f6b6a8bde43e10755b85b09516db
-  depends:
-  - __osx >=11.0
-  - filelock
-  - fmt >=12.1.0,<12.2.0a0
-  - fsspec
-  - jinja2
-  - libabseil * cxx17*
-  - libabseil >=20250512.1,<20250513.0a0
-  - libcblas >=3.9.0,<4.0a0
-  - libcxx >=19
-  - liblapack >=3.9.0,<4.0a0
-  - libprotobuf >=6.31.1,<6.31.2.0a0
-  - libtorch 2.9.1 cpu_generic_h812a54d_3
-  - libuv >=1.51.0,<2.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - llvm-openmp >=19.1.7
-  - networkx
-  - nomkl
-  - numpy >=1.23,<3
-  - optree >=0.13.0
-  - pybind11
-  - pybind11-abi 11
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  - setuptools
-  - sleef >=3.9.0,<4.0a0
-  - sympy >=1.13.3
-  - typing_extensions >=4.10.0
-  constrains:
-  - pytorch-gpu <0.0a0
-  - pytorch-cpu 2.9.1
-  license: BSD-3-Clause
-  license_family: BSD
-  purls:
-  - pkg:pypi/torch?source=hash-mapping
-  size: 24323837
-  timestamp: 1768339599540
 - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2025.2-pyhd8ed1ab_0.conda
   sha256: 8d2a8bf110cc1fc3df6904091dead158ba3e614d8402a83e51ed3a8aa93cdeb0
   md5: bc8e3267d44011051f2eb14d22fb0960
@@ -22838,22 +22504,6 @@ packages:
   purls: []
   size: 394197
   timestamp: 1765160261434
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/safetensors-0.7.0-py313h0b74987_0.conda
-  sha256: 9b0888ae4aec384e9eadd06fd68147746b29c6142f29ce3e71e3bad7b93b6d37
-  md5: 567f0002cf8fd87eac4711891464f829
-  depends:
-  - __osx >=11.0
-  - python >=3.13,<3.14.0a0
-  - python >=3.13,<3.14.0a0 *_cp313
-  - python_abi 3.13.* *_cp313
-  constrains:
-  - __osx >=11.0
-  license: Apache-2.0
-  license_family: APACHE
-  purls:
-  - pkg:pypi/safetensors?source=hash-mapping
-  size: 394462
-  timestamp: 1763570227786
 - conda: https://conda.anaconda.org/conda-forge/linux-64/scikit-learn-1.8.0-np2py313h16d504d_1.conda
   sha256: 5195fa9172a31d9f0b643c608aa90fbef4e98a50dd0d896e7d25f2939123c72c
   md5: d43a148434f123b3e060780d84a05ddc
@@ -23415,17 +23065,6 @@ packages:
   - pkg:pypi/shapely?source=hash-mapping
   size: 613015
   timestamp: 1762523741425
-- conda: https://conda.anaconda.org/conda-forge/noarch/shellingham-1.5.4-pyhd8ed1ab_2.conda
-  sha256: 1d6534df8e7924d9087bd388fbac5bd868c5bf8971c36885f9f016da0657d22b
-  md5: 83ea3a2ddb7a75c1b09cea582aa4f106
-  depends:
-  - python >=3.10
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/shellingham?source=hash-mapping
-  size: 15018
-  timestamp: 1762858315311
 - conda: https://conda.anaconda.org/conda-forge/osx-64/sigtool-codesign-0.1.3-hc0f2934_0.conda
   sha256: b89d89d0b62e0a84093205607d071932cca228d4d6982a5b073eec7e765b146d
   md5: 1261fc730f1d8af7eeea8a0024b23493
@@ -23462,17 +23101,6 @@ packages:
   - pkg:pypi/six?source=hash-mapping
   size: 18455
   timestamp: 1753199211006
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/sleef-3.9.0-hb028509_0.conda
-  sha256: 799d0578369e67b6d0d6ecdacada411c259629fc4a500b99703c5e85d0a68686
-  md5: 68f833178f171cfffdd18854c0e9b7f9
-  depends:
-  - __osx >=11.0
-  - libcxx >=19
-  - llvm-openmp >=19.1.7
-  license: BSL-1.0
-  purls: []
-  size: 587027
-  timestamp: 1756274982526
 - conda: https://conda.anaconda.org/conda-forge/linux-64/snappy-1.2.2-h03e3b7b_1.conda
   sha256: 48f3f6a76c34b2cfe80de9ce7f2283ecb55d5ed47367ba91e8bb8104e12b8f11
   md5: 98b6c9dc80eb87b2519b97bcf7e578dd
@@ -23912,21 +23540,6 @@ packages:
   purls: []
   size: 1862756
   timestamp: 1756086862067
-- conda: https://conda.anaconda.org/conda-forge/noarch/sympy-1.14.0-pyh2585a3b_105.conda
-  sha256: 09d3b6ac51d437bc996ad006d9f749ca5c645c1900a854a6c8f193cbd13f03a8
-  md5: 8c09fac3785696e1c477156192d64b91
-  depends:
-  - __unix
-  - cpython
-  - gmpy2 >=2.0.8
-  - mpmath >=0.19
-  - python >=3.9
-  license: BSD-3-Clause
-  license_family: BSD
-  purls:
-  - pkg:pypi/sympy?source=hash-mapping
-  size: 4616621
-  timestamp: 1745946173026
 - conda: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-64-2.28-h4ee821c_9.conda
   sha256: c47299fe37aebb0fcf674b3be588e67e4afb86225be4b0d452c7eb75c086b851
   md5: 13dc3adbc692664cd3beabd216434749
@@ -24286,24 +23899,6 @@ packages:
   - pkg:pypi/trove-classifiers?source=compressed-mapping
   size: 19707
   timestamp: 1768550221435
-- conda: https://conda.anaconda.org/conda-forge/noarch/typer-slim-0.21.1-pyhcf101f3_0.conda
-  sha256: 9ef3c1b5ea2b355904b94323fc3fc95a37584ef09c6c86aafe472da156aa4d70
-  md5: 3f64f1c7f9a23bead591884648949622
-  depends:
-  - python >=3.10
-  - click >=8.0.0
-  - typing_extensions >=3.7.4.3
-  - python
-  constrains:
-  - typer 0.21.1.*
-  - rich >=10.11.0
-  - shellingham >=1.3.0
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/typer-slim?source=compressed-mapping
-  size: 48131
-  timestamp: 1767711188309
 - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.15.0-h396c80c_0.conda
   sha256: 7c2df5721c742c2a47b2c8f960e718c930031663ac1174da67c1ed5999f7938c
   md5: edd329d7d3a4ab45dcf905899a7a6115

--- a/pixi.toml
+++ b/pixi.toml
@@ -67,7 +67,7 @@ jax = { version = ">=0.8, <0.9", extras = ["cuda12"] }
 tfp-nightly = "*"
 
 [target.osx-arm64.dependencies]
-libblas = { version = "*", build = "*_newaccelerate" }
+libblas = { version = "*", build = "*_*accelerate" }
 
 [feature.dev.dependencies]
 pre-commit = "*"


### PR DESCRIPTION
Change `libblas` build constraint for `osx-arm64` to `*_*accelerate` to resolve a package solver failure caused by an incorrect glob pattern in `pytensor`'s `blas` dependency.

The `pytensor-suite feedstock PR #203` introduced a `blas` constraint `*_*accelerate` for osx-arm64. This pattern incorrectly requires an underscore in the `blas` package build string (e.g., `accelerate`, `newaccelerate` do not have underscores), causing the solver to fail. Changing the `libblas` constraint to `*_*accelerate` allows the solver to find a compatible `pytensor` package (specifically, `pytensor 2.37.0 build 0` which requires `blas * accelerate`).

---
<a href="https://cursor.com/background-agent?bcId=bc-1d397d23-5f36-4457-83da-084c06542386"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1d397d23-5f36-4457-83da-084c06542386"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

